### PR TITLE
Adds a badge that links to the Gitter page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # GitComponentVersion
+
 Handles multiple versions in a single repository
+
+[![Join the chat at https://gitter.im/GitDepend/Lobby][gitter]][gitter-badge]
 
 |                            |                Stable               |                 Pre-release               |
 | -------------------------: | :---------------------------------: | :---------------------------------------: |
 |                  **Docs**  |     [![Docs][docs-badge]][docs]     |    [![Docs][docs-pre-badge]][docs-pre]    |
 
 
+[gitter]:          https://badges.gitter.im/GitComponentVersion/Lobby.svg
+[gitter-badge]:    https://gitter.im/GitComponentVersion/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 [docs]:            http://gitcomponentversion.readthedocs.org/en/stable/
 [docs-badge]:      https://readthedocs.org/projects/gitcomponentversion/badge/?version=stable
 [docs-pre]:        http://gitcomponentversion.readthedocs.org/en/latest/


### PR DESCRIPTION
Why:

* We want to have a place to talk about this project

This change addresses the need by:

* Adding a gitter badge that links to the GitComponentVersion/Lobby