### PR TITLE
Enhances the init verb to detect component folders

### DIFF
--- a/src/GitComponentVersion/Resources/strings.Designer.cs
+++ b/src/GitComponentVersion/Resources/strings.Designer.cs
@@ -79,6 +79,24 @@ namespace GitComponentVersion.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Those are all the directories that look like components..
+        /// </summary>
+        internal static string DONE_WITH_SUGGESTED_DIRECTORIES {
+            get {
+                return ResourceManager.GetString("DONE_WITH_SUGGESTED_DIRECTORIES", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter the name of a component.
+        /// </summary>
+        internal static string ENTER_COMPONENT_NAME {
+            get {
+                return ResourceManager.GetString("ENTER_COMPONENT_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid Component!.
         /// </summary>
         internal static string INVALID_COMPONENT {
@@ -156,15 +174,6 @@ namespace GitComponentVersion.Resources {
         internal static string RET_UNKNOWN_ERROR {
             get {
                 return ResourceManager.GetString("RET_UNKNOWN_ERROR", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to What is the name of this component?.
-        /// </summary>
-        internal static string WHAT_IS_THE_COMPONENT_NAME {
-            get {
-                return ResourceManager.GetString("WHAT_IS_THE_COMPONENT_NAME", resourceCulture);
             }
         }
         

--- a/src/GitComponentVersion/Resources/strings.resx
+++ b/src/GitComponentVersion/Resources/strings.resx
@@ -123,6 +123,12 @@
   <data name="COMPONENTS_SO_FAR" xml:space="preserve">
     <value>These are your components so far.</value>
   </data>
+  <data name="DONE_WITH_SUGGESTED_DIRECTORIES" xml:space="preserve">
+    <value>Those are all the directories that look like components.</value>
+  </data>
+  <data name="ENTER_COMPONENT_NAME" xml:space="preserve">
+    <value>Enter the name of a component</value>
+  </data>
   <data name="INVALID_COMPONENT" xml:space="preserve">
     <value>Invalid Component!</value>
   </data>
@@ -149,9 +155,6 @@
   </data>
   <data name="RET_UNKNOWN_ERROR" xml:space="preserve">
     <value>Unknown Error</value>
-  </data>
-  <data name="WHAT_IS_THE_COMPONENT_NAME" xml:space="preserve">
-    <value>What is the name of this component?</value>
   </data>
   <data name="WHAT_IS_THE_COMPONENT_PRE_RELEASE_TAG" xml:space="preserve">
     <value>What is the pre-release tag for this component?</value>


### PR DESCRIPTION
issue #9

Why:

* init was requiring the user to do everything, and we wanted init to be
smarter.

This change addresses the need by:

* Detecting folders that are grouping projects and suggesting those as
components.